### PR TITLE
update gemspec spina version & "jost" to "job"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
         index: All Job Postings
         title: Job Postings
         new: New Job
-        save: Save jost
+        save: Save Job
         saving: Saving...
         saved: Job saved
         job_content: Content

--- a/spina-jobs.gemspec
+++ b/spina-jobs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_runtime_dependency 'spina', '~> 1.0.0'
+  s.add_runtime_dependency 'spina', '>= 1.0.0'
   s.add_runtime_dependency 'friendly_id', '~> 5.2', '>= 5.2.1'
   s.add_runtime_dependency 'draper', '~> 3.0', '>= 3.0.0'
   s.add_runtime_dependency 'tel_link_rails', '~> 0.0.2'


### PR DESCRIPTION
Fix not being able to use `spina-jobs` on newer versions of Spina